### PR TITLE
Null check on socket

### DIFF
--- a/lib/poplib.js
+++ b/lib/poplib.js
@@ -100,9 +100,11 @@ function POP3Client(port, host, options) {
     var checkResp = true;
     var err = null;
     var detach = function() {
+     if (socket !== null) {
       socket.removeAllListeners("data");
       socket.removeAllListeners("error");
       socket.removeAllListeners("close");
+     }
     };
 
     socket.on("data", function(data) {


### PR DESCRIPTION
on error, the detach method is being called and when the close event is raised from _tls_wrap, it calls detach but the socket is already detached and the object is null.

socket.removeAllListeners fails because object is null